### PR TITLE
Update mapVBVD.py

### DIFF
--- a/mapvbvd/mapVBVD.py
+++ b/mapvbvd/mapVBVD.py
@@ -2,7 +2,7 @@ import numpy as np
 from dataclasses import dataclass, field
 import mapvbvd as pkg
 from attrdict import AttrDict, AttrMap, AttrDefault
-from tqdm import tqdm, trange
+from tqdm.auto import tqdm, trange
 from .read_twix_hdr import read_twix_hdr, twix_hdr
 from .twix_map_obj import twix_map_obj
 

--- a/mapvbvd/twix_map_obj.py
+++ b/mapvbvd/twix_map_obj.py
@@ -3,7 +3,7 @@ import numpy as np
 from scipy.interpolate import griddata
 import copy
 import time
-from tqdm import tqdm, trange
+from tqdm.auto import tqdm, trange
 import logging
 
 


### PR DESCRIPTION
I love to see, that python gains more traction in the mri space.
This is just a really minimal change: 

If tqdm gets imported from tqdm.auto, it uses the html display in jupyter notebooks.