### PR TITLE
Added function to ammend loop counters

### DIFF
--- a/mapvbvd/mapVBVD.py
+++ b/mapvbvd/mapVBVD.py
@@ -323,7 +323,7 @@ def mapVBVD(filename, quiet=False, **kwargs):
         currTwixObj.update({'hdr': currTwixObjHdr})
 
         # declare data objects:
-        mytmo = lambda dtype: twix_map_obj(dtype, filename, version, rstraj, *kwargs)
+        mytmo = lambda dtype: twix_map_obj(dtype, filename, version, rstraj, **kwargs)
         currTwixObj.update({'image': mytmo('image')})
         currTwixObj.update({'noise': mytmo('noise')})
         currTwixObj.update({'phasecor': mytmo('phasecor')})

--- a/mapvbvd/twix_map_obj.py
+++ b/mapvbvd/twix_map_obj.py
@@ -925,3 +925,18 @@ class twix_map_obj:
         out = np.ascontiguousarray(out.reshape(outSize))
 
         return out if not self.squeeze else np.squeeze(out)
+  
+    """
+      ATH added August 2021
+         alter a loop counter, for example if its missing in the mdh, add it in here, or alter it
+         the length of the new loop must be = self.NAcq
+         fixLoopCounter('Ave',newLlistAve)
+    """
+    def fixLoopCounter(self,loop,newLoop):
+        if newLoop.shape[0] != self.NAcq:
+          print('length of new array must equal NAcq: '+str(self.NAcq))
+        self.__dict__[loop] = newLoop
+        N = max(newLoop)
+        self.__dict__['N'+loop] = N
+        self.fullSize[self.dataDims.index(loop)] = N
+        


### PR DESCRIPTION
to twix_map_obj  I have added the function  fixLoopCounter(self,loop,newLoop)

in mapVBVD's class myAttrDict(AttrDict) 
I made *kwargs to **kwargs

for some reason spider required this. I think this is how it should be.