### PR TITLE
Python 3.11

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
         matrix:
             os: ["ubuntu-latest"]
-            python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+            python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Adding Python 3.11 to CI tests, to support fixes for #21.

See also https://github.com/wtclarke/spec2nii/pull/55.