### PR TITLE
Update GitHub Action

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -14,7 +14,7 @@ jobs:
             os: ["ubuntu-latest"]
             python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
           lfs: true


### PR DESCRIPTION
This should fix this CI deprecation warning:
> **Miniconda (3.10, ubuntu-latest)**
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2

![Miniconda](https://user-images.githubusercontent.com/3234522/206183594-94b1756d-e3b6-47c8-bf7c-ed18c16372ec.png)
