### PR TITLE
Do not install tests in site-packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
     url='https://github.com/wtclarke/pymapvbvd',
     long_description=long_description,
     long_description_content_type="text/markdown",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=["tests*"]),
     install_requires=install_requires,
     extras_require={"tests": ['pytest', ]},
     license_file='LICENSE',


### PR DESCRIPTION
Fixes:

```
python3.11 -m venv _e
. _e/bin/activate
pip install pymapvbvd
ls -l _e/lib/python3.11/site-packages/tests/
```

```
total 20
-rw-r--r--. 1 ben ben   39 Jul  8 17:53 __init__.py
drwxr-xr-x. 1 ben ben  254 Jul  8 17:53 __pycache__
-rw-r--r--. 1 ben ben 2436 Jul  8 17:53 test_flags.py
-rw-r--r--. 1 ben ben 2168 Jul  8 17:53 test_read.py
-rw-r--r--. 1 ben ben 1367 Jul  8 17:53 test_slicing.py
-rw-r--r--. 1 ben ben 2121 Jul  8 17:53 test_svs.py
```

That is, `pymapvbvd` is incorrectly installing its tests/ as a top-level `tests` package.