### PR TITLE
Fix issues with overflow of uint16 for very large acquisition

### DIFF
--- a/mapvbvd/twix_map_obj.py
+++ b/mapvbvd/twix_map_obj.py
@@ -431,6 +431,7 @@ class twix_map_obj:
             if len(self.Lin) > self.NLin // self.NRep:
                 logging.warning('NLin is at maximum value for uint16, this may cause issues with indexing, trrying to fix')
             self.NLin = len(self.Lin) // self.NRep
+            self.Lin = np.arange(self.NLin)
         
         # ok, let us assume for now that all NCol and NCha entries are
         # the same for all mdhs:

--- a/mapvbvd/twix_map_obj.py
+++ b/mapvbvd/twix_map_obj.py
@@ -427,7 +427,11 @@ class twix_map_obj:
         self.NIdc = np.max(self.Idc) + 1
         self.NIdd = np.max(self.Idd) + 1
         self.NIde = np.max(self.Ide) + 1
-
+        if int(self.NLin) == 1<<16:
+            if len(self.Lin) > self.NLin // self.NRep:
+                logging.warning('NLin is at maximum value for uint16, this may cause issues with indexing, trrying to fix')
+            self.NLin = len(self.Lin) // self.NRep
+        
         # ok, let us assume for now that all NCol and NCha entries are
         # the same for all mdhs:
 


### PR DESCRIPTION
Thank you so much for the wonderful package.
We noticed that for some very large acquisitions with number of lines > 65536, we dont read the entire data. 
This is a minor fix. Please let mw know if theres something better we could do.